### PR TITLE
Add default search paths

### DIFF
--- a/chnode.sh
+++ b/chnode.sh
@@ -71,7 +71,10 @@ chnode() {
 
 			--silent-refresh)
 				NODES=()
-				[ -d /usr/local/Cellar/node ] && NODES+=(/usr/local/Cellar/node/*)
+				local dir=
+				for dir in "/usr/local/Cellar/node" "/opt/nodes" "~/.nodes"; do
+					[ -d "$dir" ] && NODES+=("$dir"/*)
+				done
 				return
 				;;
 

--- a/chnode.sh
+++ b/chnode.sh
@@ -72,7 +72,11 @@ chnode() {
 			--silent-refresh)
 				NODES=()
 				local search=("/opt/nodes" "~/.nodes")
-				command -v brew &>/dev/null && search+=("$(brew --prefix)"/Cellar/node)
+				if [ -d "${HOMEBREW_PREFIX:-/usr/local}" ]; then
+					search+=("${HOMEBREW_PREFIX:-/Cellar/node}")
+				elif command -v brew &>/dev/null; then
+					search+=("$(brew --prefix)/Cellar/node")
+				fi
 
 				local dir=
 				for dir in "${search[@]}"; do

--- a/chnode.sh
+++ b/chnode.sh
@@ -76,7 +76,8 @@ chnode() {
 
 				local dir=
 				for dir in "${search[@]}"; do
-					[ -n "$(ls -A "$dir" 2>/dev/null)" ] && NODES+=("$dir"/*)
+					local nodes=("$dir"/*)
+					[ -e "${nodes[0]}" ] && NODES+=(${nodes[@]})
 				done
 				return
 				;;

--- a/chnode.sh
+++ b/chnode.sh
@@ -71,16 +71,19 @@ chnode() {
 
 			--silent-refresh)
 				NODES=()
-				local search=("/opt/nodes" "~/.nodes")
+				local search
+				search=("/opt/nodes" "~/.nodes")
 				if [ -d "${HOMEBREW_PREFIX:-/usr/local}" ]; then
 					search+=("${HOMEBREW_PREFIX:-/Cellar/node}")
 				elif command -v brew &>/dev/null; then
 					search+=("$(brew --prefix)/Cellar/node")
 				fi
 
-				local dir=
+				local dir
+				local nodes
+				[ -n "$ZSH_NAME" ] && setopt localoptions nullglob KSH_ARRAYS
 				for dir in "${search[@]}"; do
-					local nodes=("$dir"/*)
+					nodes=("$dir"/*)
 					[ -e "${nodes[0]}" ] && NODES+=(${nodes[@]})
 				done
 				return

--- a/chnode.sh
+++ b/chnode.sh
@@ -71,9 +71,12 @@ chnode() {
 
 			--silent-refresh)
 				NODES=()
+				local search=("/opt/nodes" "~/.nodes")
+				command -v brew &>/dev/null && search+=("$(brew --prefix)"/Cellar/node)
+
 				local dir=
-				for dir in "/usr/local/Cellar/node" "/opt/nodes" "~/.nodes"; do
-					[ -n "$(ls -A "$dir" 2>&-)" ] && NODES+=("$dir"/*)
+				for dir in "${search[@]}"; do
+					[ -n "$(ls -A "$dir" 2>/dev/null)" ] && NODES+=("$dir"/*)
 				done
 				return
 				;;

--- a/chnode.sh
+++ b/chnode.sh
@@ -73,7 +73,7 @@ chnode() {
 				NODES=()
 				local dir=
 				for dir in "/usr/local/Cellar/node" "/opt/nodes" "~/.nodes"; do
-					[ -d "$dir" ] && NODES+=("$dir"/*)
+					[ -n "$(ls -A "$dir" 2>&-)" ] && NODES+=("$dir"/*)
 				done
 				return
 				;;

--- a/chnode.sh
+++ b/chnode.sh
@@ -71,12 +71,13 @@ chnode() {
 
 			--silent-refresh)
 				NODES=()
+
 				local search
 				search=("/opt/nodes" "~/.nodes")
-				if [ -d "${HOMEBREW_PREFIX:-/usr/local}" ]; then
-					search+=("${HOMEBREW_PREFIX:-/Cellar/node}")
-				elif command -v brew &>/dev/null; then
-					search+=("$(brew --prefix)/Cellar/node")
+				local brewexec
+				if brewexec="$(command -v brew)"; then
+					local brewdir="${brewexec%/*/*}"
+					search+=("${brewdir}/Cellar/node")
 				fi
 
 				local dir


### PR DESCRIPTION
Paths attempted (similar to chruby):
- `$(brew --prefix)/Cellar/node`
- `/opt/nodes`
- `~/.nodes`
